### PR TITLE
Features/wes version

### DIFF
--- a/bento_wes/app.py
+++ b/bento_wes/app.py
@@ -90,15 +90,3 @@ def service_info():
         print("Error in dev-mode retrieving git information", except_name, e)
 
     return jsonify(service_info)
-
-
-# # debugger section
-if application.config["IS_RUNNING_DEV"]:
-    try:
-        import debugpy
-        DEBUGGER_PORT = int(os.environ.get("DEBUGGER_PORT", 5680))
-        debugpy.listen(("0.0.0.0", DEBUGGER_PORT))
-        print("Debugger Attached")
-    except ImportError:
-        print("Module debugpy not found. Install to enable debugging with VS-Code")
-# # end debugger section

--- a/bento_wes/app.py
+++ b/bento_wes/app.py
@@ -56,6 +56,7 @@ with application.app_context():  # pragma: no cover
         app_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
         subprocess.run(["git", "config", "--global", "--add", "safe.directory", str(app_dir)])
 
+
 # TODO: Not compatible with GA4GH WES due to conflict with GA4GH service-info (preferred)
 @application.route("/service-info", methods=["GET"])
 def service_info():

--- a/bento_wes/app.py
+++ b/bento_wes/app.py
@@ -19,6 +19,8 @@ application.config.from_object(Config)
 
 application.register_blueprint(bp_runs)
 
+path_for_git = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
 # Generic catch-all
 application.register_error_handler(
     Exception,
@@ -75,19 +77,20 @@ def service_info():
     else:
         service_info["environment"] = "dev"
         try:
-            subprocess.run(["git", "config", "--global", "--add", "safe.directory", "./bento_wes"])
+            subprocess.run(["git", "config", "--global", "--add", "safe.directory", str(path_for_git)])
             res_tag = subprocess.check_output(["git", "describe", "--tags", "--abbrev=0"])
             if res_tag:
                 service_info["git_tag"] = res_tag.decode().rstrip()
-            res_branch= subprocess.check_output(["git", "branch", "--show-current"])
+            res_branch = subprocess.check_output(["git", "branch", "--show-current"])
             if res_branch:
                 service_info["git_branch"] = res_branch.decode().rstrip()
             return jsonify(service_info)
 
-        except:
-            return flask_errors.flask_not_found_error("Error in dev-mode retrieving git information")
-    
-        
+        except Exception as e:
+            except_name = type(e).__name__
+            return flask_errors.flask_not_found_error("Error in dev-mode retrieving git information", except_name)
+
+
 # # debugger section
 if application.config["BENTO_DEBUG"]:
     try:

--- a/bento_wes/app.py
+++ b/bento_wes/app.py
@@ -53,8 +53,8 @@ with application.app_context():  # pragma: no cover
         update_db()
 
     if application.config["BENTO_DEBUG"]:
-        path_for_git = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-        subprocess.run(["git", "config", "--global", "--add", "safe.directory", str(path_for_git)])
+        app_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        subprocess.run(["git", "config", "--global", "--add", "safe.directory", str(app_dir)])
 
 # TODO: Not compatible with GA4GH WES due to conflict with GA4GH service-info (preferred)
 @application.route("/service-info", methods=["GET"])
@@ -83,11 +83,12 @@ def service_info():
         res_branch = subprocess.check_output(["git", "branch", "--show-current"])
         if res_branch:
             service_info["git_branch"] = res_branch.decode().rstrip()
-        return jsonify(service_info)
 
     except Exception as e:
         except_name = type(e).__name__
-        return flask_errors.flask_not_found_error("Error in dev-mode retrieving git information", except_name)
+        print("Error in dev-mode retrieving git information", except_name, e)
+
+    return jsonify(service_info)
 
 
 # # debugger section

--- a/bento_wes/app.py
+++ b/bento_wes/app.py
@@ -52,7 +52,7 @@ with application.app_context():  # pragma: no cover
     else:
         update_db()
 
-    if application.config["BENTO_DEBUG"]:
+    if application.config["IS_RUNNING_DEV"]:
         app_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
         subprocess.run(["git", "config", "--global", "--add", "safe.directory", str(app_dir)])
 
@@ -73,7 +73,7 @@ def service_info():
             "version": bento_wes.__version__,
             "environment": "prod"
     }
-    if not application.config["BENTO_DEBUG"]:
+    if not application.config["IS_RUNNING_DEV"]:
         return jsonify(service_info)
 
     service_info["environment"] = "dev"
@@ -93,7 +93,7 @@ def service_info():
 
 
 # # debugger section
-if application.config["BENTO_DEBUG"]:
+if application.config["IS_RUNNING_DEV"]:
     try:
         import debugpy
         DEBUGGER_PORT = int(os.environ.get("DEBUGGER_PORT", 5680))

--- a/bento_wes/app.py
+++ b/bento_wes/app.py
@@ -19,8 +19,6 @@ application.config.from_object(Config)
 
 application.register_blueprint(bp_runs)
 
-path_for_git = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-
 # Generic catch-all
 application.register_error_handler(
     Exception,
@@ -54,6 +52,9 @@ with application.app_context():  # pragma: no cover
     else:
         update_db()
 
+    if application.config["BENTO_DEBUG"]:
+        path_for_git = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        subprocess.run(["git", "config", "--global", "--add", "safe.directory", str(path_for_git)])
 
 # TODO: Not compatible with GA4GH WES due to conflict with GA4GH service-info (preferred)
 @application.route("/service-info", methods=["GET"])
@@ -76,7 +77,6 @@ def service_info():
 
     service_info["environment"] = "dev"
     try:
-        subprocess.run(["git", "config", "--global", "--add", "safe.directory", str(path_for_git)])
         res_tag = subprocess.check_output(["git", "describe", "--tags", "--abbrev=0"])
         if res_tag:
             service_info["git_tag"] = res_tag.decode().rstrip()

--- a/bento_wes/app.py
+++ b/bento_wes/app.py
@@ -74,21 +74,20 @@ def service_info():
     if not application.config["BENTO_DEBUG"]:
         return jsonify(service_info)
 
-    else:
-        service_info["environment"] = "dev"
-        try:
-            subprocess.run(["git", "config", "--global", "--add", "safe.directory", str(path_for_git)])
-            res_tag = subprocess.check_output(["git", "describe", "--tags", "--abbrev=0"])
-            if res_tag:
-                service_info["git_tag"] = res_tag.decode().rstrip()
-            res_branch = subprocess.check_output(["git", "branch", "--show-current"])
-            if res_branch:
-                service_info["git_branch"] = res_branch.decode().rstrip()
-            return jsonify(service_info)
+    service_info["environment"] = "dev"
+    try:
+        subprocess.run(["git", "config", "--global", "--add", "safe.directory", str(path_for_git)])
+        res_tag = subprocess.check_output(["git", "describe", "--tags", "--abbrev=0"])
+        if res_tag:
+            service_info["git_tag"] = res_tag.decode().rstrip()
+        res_branch = subprocess.check_output(["git", "branch", "--show-current"])
+        if res_branch:
+            service_info["git_branch"] = res_branch.decode().rstrip()
+        return jsonify(service_info)
 
-        except Exception as e:
-            except_name = type(e).__name__
-            return flask_errors.flask_not_found_error("Error in dev-mode retrieving git information", except_name)
+    except Exception as e:
+        except_name = type(e).__name__
+        return flask_errors.flask_not_found_error("Error in dev-mode retrieving git information", except_name)
 
 
 # # debugger section

--- a/bento_wes/config.py
+++ b/bento_wes/config.py
@@ -17,6 +17,7 @@ class Config:
     CHORD_URL = os.environ.get("CHORD_URL", "http://127.0.0.1:5000/")
     BENTO_DEBUG = os.environ.get("CHORD_DEBUG", os.environ.get("FLASK_ENV", "production")).strip().lower() in (
         "true", "1", "development")
+    IS_RUNNING_DEV = os.environ.get("FLASK_DEBUG", "false").strip().lower() in ("true", "1")
 
     DATABASE = os.environ.get("DATABASE", "bento_wes.db")
     SERVICE_ID = SERVICE_ID

--- a/bento_wes/package.cfg
+++ b/bento_wes/package.cfg
@@ -1,5 +1,5 @@
 [package]
 name = bento_wes
-version = 0.5.2
+version = 0.6.0
 authors = David Lougheed, Simon Chénard
 author_emails = david.lougheed@mail.mcgill.ca, simon.chenard2@mcgill.ca


### PR DESCRIPTION
-In app.py in the route /service-info, a check was added for environment mode; if it is in dev mode will run a subprocess to retrieve information from git_branch and git_tag. The information about the environment mode is obtained from config.py BENTO_DEBUG

-The response from /service-info should contain git information and <environment: dev> information when make run-drs-dev is executed