### PR TITLE
refact: mount decoupling for object storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ htmlcov/
 celery.log
 bento_services.json
 bento_wes/*.json
+data/
 
 cromwell-executions
 cromwell-workflow-logs

--- a/bento_wes/backends/wes_backend.py
+++ b/bento_wes/backends/wes_backend.py
@@ -257,7 +257,7 @@ class WESBackend(ABC):
         """
         Downloads the input file from Drop-Box in the run directory.
         Returns the path to the temp file to inject in the workflow parameters.
-        
+
         This makes the interactions between WES and Drop-Box purely network based,
         which is necessary for object storage backends like S3.
         """
@@ -293,7 +293,6 @@ class WESBackend(ABC):
         with open(tmp_file_path, 'wb') as f:
             f.write(response.content)
         return tmp_file_path
-
 
     def download_input_files_array(self,  file_array: list[str], token: str, run_dir: Path):
         tmp_array = [self.download_input_file(file_path, token, run_dir) for file_path in file_array]
@@ -418,9 +417,6 @@ class WESBackend(ABC):
         # -- Store input for the workflow in a file in the temporary folder --------------------------------------------
         with open(self._params_path(run), "w") as pf:
             pf.write(self._serialize_params(workflow_params_with_secrets))
-
-        # -- Download input file from drop-box
-
 
         # -- Create the runner command based on inputs -----------------------------------------------------------------
         cmd = self._get_command(self.workflow_path(run), self._params_path(run), self.run_dir(run))

--- a/bento_wes/backends/wes_backend.py
+++ b/bento_wes/backends/wes_backend.py
@@ -17,7 +17,7 @@ from bento_wes.constants import SERVICE_ARTIFACT
 from bento_wes.db import Database, get_db
 from bento_wes.models import Run, RunWithDetails, RunOutput
 from bento_wes.states import STATE_EXECUTOR_ERROR, STATE_SYSTEM_ERROR
-from bento_wes.utils import iso_now
+from bento_wes.utils import get_object_drop_box_url, iso_now
 from bento_wes.workflows import WorkflowType, WorkflowManager
 
 from .backend_types import Command, ProcessResult
@@ -267,15 +267,13 @@ class WESBackend(ABC):
         validate_ssl = current_app.config["BENTO_VALIDATE_SSL"]
         self.log_debug(f"Downloading input {input} from dropbox")
 
-        # TODO: parametrize drop-box url
-        url = f"https://bentov2.local/api/drop-box/objects{obj_path}"
+        download_url = get_object_drop_box_url(obj_path)
 
         file_name = obj_path.split("/")[-1]
         tmp_file_path = f"{run_dir}/{file_name}"
 
-        # TODO: WES client requires grant 'view:drop_box' (docs)
         with requests.get(
-            url,
+            download_url,
             headers={"Authorization": f"Bearer {token}"},
             verify=validate_ssl,
             stream=True

--- a/bento_wes/backends/wes_backend.py
+++ b/bento_wes/backends/wes_backend.py
@@ -257,7 +257,7 @@ class WESBackend(ABC):
             # Invalid/non-workflow-specifying WDL file if false-y
             return workflow_id_match.group(1) if workflow_id_match else None
 
-    def _download_to_path(self, url: str, token: str, destination: str):
+    def _download_to_path(self, url: str, token: str, destination: Path | str):
         """
         Download a file from a URL to a destination directory.
         Bearer token auth works with Drop-Box and DRS.
@@ -333,7 +333,6 @@ class WESBackend(ABC):
         run_dir: Path,
         ignore_extensions: tuple[str] | None = None
     ) -> str:
-        validate_ssl = current_app.config["BENTO_VALIDATE_SSL"]
         drop_box_url = get_bento_service_kind_url("drop-box")
 
         sub_tree = directory.lstrip("/")
@@ -352,7 +351,7 @@ class WESBackend(ABC):
         with requests.get(
             url,
             headers={"Authorization": f"Bearer {token}"},
-            verify=validate_ssl,
+            verify=self.validate_ssl,
             stream=True
         ) as response:
             if response.status_code != 200:
@@ -638,7 +637,7 @@ class WESBackend(ABC):
         # Initialization (loading / downloading files + secrets injection) ---------------------------------------------
         init_vals = self._initialize_run_and_get_command(run, celery_id, secrets)
         if init_vals is None:
-            return
+            return None
 
         cmd, params_with_secrets = init_vals
 

--- a/bento_wes/backends/wes_backend.py
+++ b/bento_wes/backends/wes_backend.py
@@ -439,7 +439,7 @@ class WESBackend(ABC):
                     injected_input = self._download_input_file(input_param, secrets["access_token"], run_dir)
                 processed_workflow_params[param_key] = injected_input
             elif isinstance(run_input, WorkflowDirectoryInput):
-                # Finds workfloe inputs for a drop-box directory
+                # Finds workflow inputs for a drop-box directory
                 # Downloads the directory's contents to a temp directory and injects the path
                 param_key = namespaced_input(run_req.tags.workflow_id, run_input.id)
                 input_param = run_req.workflow_params.get(param_key)

--- a/bento_wes/backends/wes_backend.py
+++ b/bento_wes/backends/wes_backend.py
@@ -14,6 +14,7 @@ from bento_lib.workflows.models import (
 from bento_lib.workflows.utils import namespaced_input
 from flask import current_app
 from pathlib import Path
+from typing import overload
 
 from bento_wes import states
 from bento_wes.constants import SERVICE_ARTIFACT
@@ -279,9 +280,15 @@ class WESBackend(ABC):
                     f.write(chunk)
         self.log_debug(f"Downloaded file at {url} to path {destination}")
 
+    @overload
+    def _download_input_files(self, inputs: str, token: str, run_dir: Path) -> str: ...
+
+    @overload
+    def _download_input_files(self, inputs: list[str], token: str, run_dir: Path) -> list[str]: ...
+
     def _download_input_files(self, inputs: str | list[str], token: str, run_dir: Path) -> str | list[str]:
         if not inputs:
-            # Ignore empty imputs
+            # Ignore empty inputs
             return inputs
 
         if isinstance(inputs, list):
@@ -313,7 +320,7 @@ class WESBackend(ABC):
         run_dir: Path,
     ):
         """
-        Downloads the contents of a given Drop-Box tree or sub-tree to the temporary run_dir directory
+        Downloads the contents of a given Drop Box tree or subtree to the temporary run_dir directory
         e.g. /wes/tmp/<Run ID>/<Dir Tree>
         """
         for node in tree:
@@ -347,7 +354,7 @@ class WESBackend(ABC):
             # add ignore query params
             url = f"{url}?{ignore_param}"
 
-        # Fetch directory sub-tree from Drop-Box
+        # Fetch directory subtree from Drop Box
         with requests.get(
             url,
             headers={"Authorization": f"Bearer {token}"},
@@ -357,7 +364,7 @@ class WESBackend(ABC):
             if response.status_code != 200:
                 raise RunExceptionWithFailState(
                     STATE_EXECUTOR_ERROR,
-                    f"Tree request to drop-box resulted in a non 200 status code: {response.status_code}"
+                    f"Tree request to drop box resulted in a non 200 status code: {response.status_code}"
                 )
             tree = response.json()
             # Download tree content under run_dir

--- a/bento_wes/backends/wes_backend.py
+++ b/bento_wes/backends/wes_backend.py
@@ -281,21 +281,22 @@ class WESBackend(ABC):
 
     def _download_input_files(self, inputs: str | list[str], token: str, run_dir: Path) -> str | list[str]:
         if not inputs:
-            return []
+            # Ignore empty imputs
+            return inputs
 
         if isinstance(inputs, list):
             return [self._download_input_file(f) for f in inputs]
         else:
             return self._download_input_file(inputs, token, run_dir)
 
-    def _download_input_file(self, obj_path: str, token: str, run_dir: Path) -> str | None:
+    def _download_input_file(self, obj_path: str, token: str, run_dir: Path) -> str:
         """
         Downloads an input file from Drop-Box in the run directory.
         Returns the path to the temp file to inject in the workflow params.
         """
         if not obj_path:
             # Ignore empty inputs (e.g. reference genome ingestion with no GFF3 files)
-            return None
+            return obj_path
 
         file_name = obj_path.split("/")[-1]
         tmp_file_path = f"{run_dir}/{file_name}"

--- a/bento_wes/backends/wes_backend.py
+++ b/bento_wes/backends/wes_backend.py
@@ -265,7 +265,7 @@ class WESBackend(ABC):
         with requests.get(
             url,
             headers={"Authorization": f"Bearer {token}"},
-            verify=current_app.config["BENTO_VALIDATE_SSL"],
+            verify=self.validate_ssl,
             stream=True
         ) as response:
             if response.status_code != 200:

--- a/bento_wes/backends/wes_backend.py
+++ b/bento_wes/backends/wes_backend.py
@@ -285,7 +285,7 @@ class WESBackend(ABC):
             return inputs
 
         if isinstance(inputs, list):
-            return [self._download_input_file(f) for f in inputs]
+            return [self._download_input_file(f, token, run_dir) for f in inputs]
         else:
             return self._download_input_file(inputs, token, run_dir)
 

--- a/bento_wes/backends/wes_backend.py
+++ b/bento_wes/backends/wes_backend.py
@@ -14,7 +14,7 @@ from bento_lib.workflows.models import (
 from bento_lib.workflows.utils import namespaced_input
 from flask import current_app
 from pathlib import Path
-from typing import overload
+from typing import overload, Sequence
 
 from bento_wes import states
 from bento_wes.constants import SERVICE_ARTIFACT
@@ -338,7 +338,7 @@ class WESBackend(ABC):
         directory: str,
         token: str,
         run_dir: Path,
-        ignore_extensions: tuple[str] | None = None
+        ignore_extensions: Sequence[str] | None = None,
     ) -> str:
         drop_box_url = get_bento_service_kind_url("drop-box")
 
@@ -485,9 +485,7 @@ class WESBackend(ABC):
 
                 # TODO: directory workflows should simply include a list of file extentions to filter out.
                 filter_vcfs = run_req.workflow_params.get("experiments_json_with_files.filter_out_vcf_files")
-                filter_extensions: tuple[str, ...] | None = None
-                if filter_vcfs:
-                    filter_extensions = ('.vcf', '.vcf.gz')
+                filter_extensions: tuple[str, ...] | None = (".vcf", ".vcf.gz") if filter_vcfs else None
 
                 if not skip_file_input_injection:
                     injected_dir = self._download_input_directory(

--- a/bento_wes/backends/wes_backend.py
+++ b/bento_wes/backends/wes_backend.py
@@ -273,25 +273,15 @@ class WESBackend(ABC):
                     STATE_EXECUTOR_ERROR,
                     f"Download request to drop-box resulted in a non 200 status code: {response.status_code}"
                 )
-            with open(destination, 'wb') as f:
+            with open(destination, "wb") as f:
                 # chunk_size=None to use the chunk size from the stream
                 for chunk in response.iter_content(chunk_size=None):
                     f.write(chunk)
         self.log_debug(f"Downloaded file at {url} to path {destination}")
 
-    def _inputs_url_refs(self, files: str | list[str]) -> str | list[str] | None:
-        if not files:
-            return None
-
-        if isinstance(files, list):
-            input_files = [get_drop_box_resource_url(f_path) for f_path in files]
-        else:
-            input_files = get_drop_box_resource_url(files)
-        return input_files
-
-    def _download_input_files(self, inputs: str | list[str], token: str, run_dir: Path) -> str | list[str] | None:
+    def _download_input_files(self, inputs: str | list[str], token: str, run_dir: Path) -> str | list[str]:
         if not inputs:
-            return None
+            return []
 
         if isinstance(inputs, list):
             return [self._download_input_file(f) for f in inputs]

--- a/bento_wes/backends/wes_backend.py
+++ b/bento_wes/backends/wes_backend.py
@@ -479,7 +479,7 @@ class WESBackend(ABC):
 
                 # TODO: directory workflows should simply include a list of file extentions to filter out.
                 filter_vcfs = run_req.workflow_params.get("experiments_json_with_files.filter_out_vcf_files")
-                filter_extensions: tuple[str] | None = None
+                filter_extensions: tuple[str, ...] | None = None
                 if filter_vcfs:
                     filter_extensions = ('.vcf', '.vcf.gz')
 

--- a/bento_wes/service_registry.py
+++ b/bento_wes/service_registry.py
@@ -4,6 +4,7 @@ from flask import current_app
 
 __all__ = [
     "get_bento_services",
+    "get_bento_service_kind_url",
 ]
 
 
@@ -35,6 +36,7 @@ def get_bento_services() -> dict:
 
 
 def get_bento_service_kind_url(kind: str) -> str | None:
+    # TODO: replace this with upcoming bento_lib service registry utils
     services = get_bento_services()
     service_details: dict | None = services.get(kind)
     if service_details:

--- a/bento_wes/service_registry.py
+++ b/bento_wes/service_registry.py
@@ -36,6 +36,6 @@ def get_bento_services() -> dict:
 
 def get_bento_service_kind_url(kind: str) -> str | None:
     services = get_bento_services()
-    service_details: dict = services.get(kind)
+    service_details: dict | None = services.get(kind)
     if service_details:
         return service_details.get("url")

--- a/bento_wes/service_registry.py
+++ b/bento_wes/service_registry.py
@@ -37,7 +37,5 @@ def get_bento_services() -> dict:
 
 def get_bento_service_kind_url(kind: str) -> str | None:
     # TODO: replace this with upcoming bento_lib service registry utils
-    services = get_bento_services()
-    service_details: dict | None = services.get(kind)
-    if service_details:
-        return service_details.get("url")
+    service_details: dict | None = get_bento_services().get(kind)
+    return (service_details or {}).get("url")

--- a/bento_wes/service_registry.py
+++ b/bento_wes/service_registry.py
@@ -32,3 +32,10 @@ def get_bento_services() -> dict:
         _bento_services_last_updated = datetime.now()
 
     return _bento_services_cache
+
+
+def get_bento_service_kind_url(kind: str) -> str | None:
+    services = get_bento_services()
+    service_details: dict = services.get(kind)
+    if service_details:
+        return service_details.get("url")

--- a/bento_wes/utils.py
+++ b/bento_wes/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Literal
 
 from bento_wes.service_registry import get_bento_service_kind_url
 
@@ -10,7 +11,7 @@ def iso_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")  # ISO date format
 
 
-def get_object_drop_box_url(path: str) -> str:
+def get_drop_box_resource_url(path: str, resource: Literal["objects", "tree"] = "objects") -> str:
     drop_box_url = get_bento_service_kind_url("drop-box")
     clean_path = path.lstrip("/")
-    return f"{drop_box_url}/objects/{clean_path}"
+    return f"{drop_box_url}/{resource}/{clean_path}"

--- a/bento_wes/utils.py
+++ b/bento_wes/utils.py
@@ -1,8 +1,16 @@
 from datetime import datetime, timezone
 
+from bento_wes.service_registry import get_bento_service_kind_url
+
 
 __all__ = ["iso_now"]
 
 
 def iso_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")  # ISO date format
+
+
+def get_object_drop_box_url(path: str) -> str:
+    drop_box_url = get_bento_service_kind_url("drop-box")
+    clean_path = path.lstrip("/")
+    return f"{drop_box_url}/objects/{clean_path}"

--- a/bento_wes/utils.py
+++ b/bento_wes/utils.py
@@ -4,7 +4,7 @@ from typing import Literal
 from bento_wes.service_registry import get_bento_service_kind_url
 
 
-__all__ = ["iso_now"]
+__all__ = ["iso_now", "get_drop_box_resource_url"]
 
 
 def iso_now() -> str:

--- a/bento_wes/workflows.py
+++ b/bento_wes/workflows.py
@@ -15,6 +15,7 @@ __all__ = [
     "WorkflowType",
     "WES_WORKFLOW_TYPE_WDL",
     "WES_WORKFLOW_TYPE_CWL",
+    "WORKFLOW_USE_INPUT_URL_FILE_REF",
     "parse_workflow_host_allow_list",
     "UnsupportedWorkflowType",
     "WorkflowDownloadError",
@@ -38,6 +39,10 @@ ALLOWED_WORKFLOW_URL_SCHEMES = ("http", "https", "file")
 ALLOWED_WORKFLOW_REQUEST_SCHEMES = ("http", "https")
 
 MAX_WORKFLOW_FILE_BYTES = 50000  # 50 KB
+
+# Workflow IDs for which input file(s) must be a URL reference, instead of an injected temp file.
+# TODO: find a way for WES to get this info from the workflow/service, instead of hard-coding
+WORKFLOW_USE_INPUT_URL_FILE_REF = ["vcf_gz"]
 
 
 def parse_workflow_host_allow_list(allow_list: str | None) -> set[str] | None:

--- a/bento_wes/workflows.py
+++ b/bento_wes/workflows.py
@@ -15,7 +15,7 @@ __all__ = [
     "WorkflowType",
     "WES_WORKFLOW_TYPE_WDL",
     "WES_WORKFLOW_TYPE_CWL",
-    "WORKFLOW_USE_INPUT_URL_FILE_REF",
+    "WORKFLOW_IGNORE_FILE_PATH_INJECTION",
     "parse_workflow_host_allow_list",
     "UnsupportedWorkflowType",
     "WorkflowDownloadError",
@@ -42,7 +42,7 @@ MAX_WORKFLOW_FILE_BYTES = 50000  # 50 KB
 
 # Workflow IDs for which input file(s) must be a URL reference, instead of an injected temp file.
 # TODO: find a way for WES to get this info from the workflow/service, instead of hard-coding
-WORKFLOW_USE_INPUT_URL_FILE_REF = ["vcf_gz"]
+WORKFLOW_IGNORE_FILE_PATH_INJECTION = ["vcf_gz"]
 
 
 def parse_workflow_host_allow_list(allow_list: str | None) -> set[str] | None:

--- a/bento_wes/workflows.py
+++ b/bento_wes/workflows.py
@@ -35,14 +35,13 @@ WORKFLOW_EXTENSIONS: dict[WorkflowType, str] = {
     WES_WORKFLOW_TYPE_CWL: "cwl",
 }
 
-ALLOWED_WORKFLOW_URL_SCHEMES = ("http", "https", "file")
 ALLOWED_WORKFLOW_REQUEST_SCHEMES = ("http", "https")
 
 MAX_WORKFLOW_FILE_BYTES = 50000  # 50 KB
 
 # Workflow IDs for which input file(s) must be a URL reference, instead of an injected temp file.
 # TODO: find a way for WES to get this info from the workflow/service, instead of hard-coding
-WORKFLOW_IGNORE_FILE_PATH_INJECTION = ["vcf_gz"]
+WORKFLOW_IGNORE_FILE_PATH_INJECTION = frozenset({"vcf_gz"})
 
 
 def parse_workflow_host_allow_list(allow_list: str | None) -> set[str] | None:


### PR DESCRIPTION
# Issue
Currently, a WES container needs to mount the data volumes for Drop-Box and DRS, all WES operations related to files are made with the assumption that the files are accessible in a POSIX file system.

This will not work when Drop-Box and DRS are using object storage backends like S3.

This PR refactors WES so that all of its operations wrt Drop-Box and DRS are made over the network.

# Solution
Proposed approach:
- Remove volume mounts for Drop-Box and DRS
- Workflow execution with input file(s)
   - Download files from Drop-Box to the temp run directory
      - HTTP Call to Drop-Box with access token
   - Override input value to point to the temp files (similar to secret injection)
- Requires extra WES grant `view:drop_box` to authorize download from Drop-Box

Referenced in Bento S3 [PR](https://github.com/bento-platform/bento/pull/306)